### PR TITLE
New functionnalities by StarXpert

### DIFF
--- a/zimlet/OwnCloudCommons.js
+++ b/zimlet/OwnCloudCommons.js
@@ -162,12 +162,23 @@ OwnCloudCommons.prototype._createShareCbk = function(resource, resources, links,
  * @param {string} data
  * @private
  */
-OwnCloudCommons.prototype._getResourceCbk = function(resource, resources, ids, callback, data) {
+OwnCloudCommons.prototype._getResourceCbk = function(resource, resources, ids, callback, data, progressBarId) {
   var req = new XMLHttpRequest();
   if (!req.responseURL)
   {
     req.responseURL = '/service/upload?fmt=extended,raw';
   }
+  
+  function progressFunction(evt) {
+    var progressBar = document.getElementById(progressBarId);
+    if(progressBar) {
+      if (evt.lengthComputable) {  
+        progressBar.max = evt.total;
+        progressBar.value = evt.loaded;
+      }
+    }
+  }
+
   req.open('POST', '/service/upload?fmt=extended,raw', true);
   req.setRequestHeader('Cache-Control', 'no-cache');
   req.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
@@ -192,6 +203,10 @@ OwnCloudCommons.prototype._getResourceCbk = function(resource, resources, ids, c
       }   
     };
   }(this, resources, ids, callback));
+  
+  if(progressBarId) {
+      req.upload.addEventListener("progress", progressFunction, false);
+  }
 
   var dataBin = OwnCloudCommons.prototype.base64DecToArr(data);
   var blob = new Blob([dataBin], { type: 'octet/stream' });

--- a/zimlet/tk_barrydegraaff_owncloud_zimlet.js
+++ b/zimlet/tk_barrydegraaff_owncloud_zimlet.js
@@ -788,7 +788,6 @@ ownCloudZimlet.prototype._uploadFilesFromFormCbk = function (files , response) {
       var handler = function(status)
       {
          //Manage upload aborted
-         console.log("test" + status);
          if(status!="0") {
             uploadFileCount++;
          }
@@ -929,6 +928,19 @@ ownCloudZimlet.prototype._menuButtonListener = function (controller) {
  */
 ownCloudZimlet.prototype.doDrop =
   function(zmObjects) {
+   /* Single selects result in an object passed,
+   Multi selects results in an array of objects passed.
+   Always make it an array */    
+   if(!dropObjects[0])
+   {
+      dropObjects = [dropObjects];
+   }
+   var i = 0;
+   var zmObjects = [];
+   dropObjects.forEach(function(dropObject)
+   {
+      zmObjects[i++] = dropObject.srcObj;
+   });
   this.uploadItems(zmObjects);
 }
 
@@ -1011,10 +1023,6 @@ ownCloudZimlet.prototype._doDropPropfindCbk = function(zmObjects, callback, erro
      type = "MESSAGE",
      iObj = 0,
      tmpObj;
-
-   if (!zmObjects[0]) {
-      zmObjects = [zmObjects];
-   }
     
    var items = [];
    var index = 0;
@@ -1026,15 +1034,15 @@ ownCloudZimlet.prototype._doDropPropfindCbk = function(zmObjects, callback, erro
 
       var fileName = "";
       //if its a conversation i.e. 'ZmConv' object, get the first loaded message 'ZmMailMsg' object within that.
-      if (tmpObj.TYPE === 'ZmConv') {
-         var msgObj = tmpObj.srcObj; // get access to source-object
-         msgObj = msgObj.getFirstHotMsg();
+      if (tmpObj.type == "CONV") {
+         var msgObj = tmpObj;
+         msgObj  = msgObj.getFirstHotMsg();
          tmpObj.id = msgObj.id;
          type = 'MESSAGE';
          fileName = (tmpObj.subject ? tmpObj.subject + '.eml' : tmpObj.id + '.eml');
       }
       
-      if(tmpObj.TYPE==='ZmMailMsg')
+      if(tmpObj.type ==='MSG')
       {
          fileName = (tmpObj.subject ? tmpObj.subject + '.eml' : tmpObj.id + '.eml');
       }
@@ -1048,12 +1056,12 @@ ownCloudZimlet.prototype._doDropPropfindCbk = function(zmObjects, callback, erro
       if (tmpObj.type === 'BRIEFCASE_ITEM') {
          type = 'DOCUMENT';
          fileName = tmpObj.name;
-      } else if (tmpObj.TYPE === 'ZmContact') {
+      } else if (tmpObj.type === 'CONTACT') {
          type = 'CONTACT';
-         fileName = (tmpObj.email ? tmpObj.email + '.vcf' : tmpObj.id + '.vcf');
-      } else if (tmpObj.TYPE === 'ZmAppt') {
+         fileName = (tmpObj.attr.email ? tmpObj.attr.email + '.vcf' : tmpObj.id + '.vcf');
+      } else if (tmpObj.type === 'APPT') {
          type = 'APPOINTMENT';
-         fileName = tmpObj.subject + '.ics'
+         fileName = tmpObj.name + '.ics'
       } else if (tmpObj.type === 'TASK') {
          type = 'TASK';
          fileName = tmpObj.name + '.ics'

--- a/zimlet/tk_barrydegraaff_owncloud_zimlet.js
+++ b/zimlet/tk_barrydegraaff_owncloud_zimlet.js
@@ -27,6 +27,7 @@ tk_barrydegraaff_owncloud_zimlet_HandlerObject.prototype = new ZmZimletBase();
 tk_barrydegraaff_owncloud_zimlet_HandlerObject.prototype.constructor = tk_barrydegraaff_owncloud_zimlet_HandlerObject;
 var ownCloudZimlet = tk_barrydegraaff_owncloud_zimlet_HandlerObject;
 var ownCloudZimletInstance;
+var ownCloudUploadFileCount = 0;
 //List of data to manage simultanuous upload;
 var ownCloudZimletUploadList = new Array();
 
@@ -607,14 +608,20 @@ ownCloudZimlet.prototype.makeDlg = function(title, size, content, standardButton
 
 // Ask user to use ownCloud for upload
 ownCloudZimlet.prototype.popUseOwncloudDlg = function(files) {
-   var label = this.getMessage('useOwncloudDlgLabel1');
+   var i = 0;
+   var tabLabel = [];
+   tabLabel[i++] = (this.getMessage('useOwncloudDlgLabel1').indexOf('???') == 0) ? '<span>Attachments larger than' : this.getMessage('useOwncloudDlgLabel1');
    //Max mail size in Mo
-   var label = label + " " + Math.floor(appCtxt.get(ZmSetting.MESSAGE_SIZE_LIMIT)/(1024*1024)) + " ";
-   var label = label + this.getMessage('useOwncloudDlgLabel2');
+   tabLabel[i++] = " " + Math.floor(appCtxt.get(ZmSetting.MESSAGE_SIZE_LIMIT)/(1024*1024)) + " ";
+   tabLabel[i++] = (this.getMessage('useOwncloudDlgLabel2').indexOf('???') == 0) ? 'MB will be <br>uploaded to' : this.getMessage('useOwncloudDlgLabel2');
+   tabLabel[i++] = " " + this._zimletContext.getConfig("owncloud_zimlet_app_title");
+   tabLabel[i++] = (this.getMessage('useOwncloudDlgLabel3').indexOf('???') == 0) ? '. A download link<br>will be included in your email.</span>' : this.getMessage('useOwncloudDlgLabel3');
+   var label = tabLabel.join("");
 
    if(!ownCloudZimlet.settings['owncloud_zimlet_password'])
    {
-      var prompt = '<span id=\'passpromptOuter\'><br>' + ownCloudZimletInstance.getMessage("passwordPrompt") + ': <input type=\'password\' id=\'first_use_passprompt\'></span>';
+      var passwordPromptLabel = (ownCloudZimletInstance.getMessage('passwordPrompt').indexOf('???') == 0) ? 'Your password is required for sharing links' : ownCloudZimletInstance.getMessage('passwordPrompt');
+      var prompt = '<span id=\'passpromptOuter\'><br>' + passwordPromptLabel + ': <input type=\'password\' id=\'first_use_passprompt\'></span>';
    }
    else
    {
@@ -622,8 +629,9 @@ ownCloudZimlet.prototype.popUseOwncloudDlg = function(files) {
    }
    label = label + "<br>" + prompt;
 
+   var dialogLabel = (this.getMessage('useOwncloudDlgTitle').indexOf('???') == 0) ? 'Large files must be shared with ' + this._zimletContext.getConfig("owncloud_zimlet_app_title") : this.getMessage('useOwncloudDlgTitle') + " " + this._zimletContext.getConfig("owncloud_zimlet_app_title");
    var dialog = this.makeDlg(
-      this.getMessage('useOwncloudDlgTitle'),
+      dialogLabel,
       {width: 300, height: 150},
       label,
       [DwtDialog.OK_BUTTON, DwtDialog.CANCEL_BUTTON]
@@ -645,7 +653,7 @@ ownCloudZimlet.prototype.popUseOwncloudDlg = function(files) {
          if(!ownCloudZimlet.settings['owncloud_zimlet_password'])
          {
             var dlg = appCtxt.getMsgDialog();
-            var msg = this.getMessage('passwordRequired');
+            var msg = (this.getMessage('passwordRequired').indexOf('???') == 0) ? 'Your password is required to go further.' : this.getMessage('passwordRequired');
             style = DwtMessageDialog.CRITICAL_STYLE;
             dlg.reset();
             dlg.setMessage(msg, style);
@@ -666,10 +674,15 @@ ownCloudZimlet.prototype.popUseOwncloudDlg = function(files) {
 
 // Ask user to use ownCloud for upload
 ownCloudZimlet.prototype.popUploadToOwncloudDlg = function(files) {
-   var label = this.getMessage('uploadToOwncloudDlgLabel1');
+   var i = 0;
+   var tabLabel = [];
+   tabLabel[i++] = (this.getMessage('uploadToOwncloudDlgLabel1').indexOf('???') == 0) ? '<span>The size of the files is over' : this.getMessage('uploadToOwncloudDlgLabel1');
    //Max mail size in Mo
-   var label = label + " " + Math.floor(appCtxt.get(ZmSetting.MESSAGE_SIZE_LIMIT)/(1024*1024)) + " ";
-   var label = label + this.getMessage('uploadToOwncloudDlgLabel2');
+   tabLabel[i++] =  " " + Math.floor(appCtxt.get(ZmSetting.MESSAGE_SIZE_LIMIT)/(1024*1024)) + " ";
+   tabLabel[i++] = (this.getMessage('uploadToOwncloudDlgLabel2').indexOf('???') == 0) ? 'MB. The files will be uploaded as' : this.getMessage('uploadToOwncloudDlgLabel2');
+   tabLabel[i++] =  " " + this._zimletContext.getConfig("owncloud_zimlet_app_title") + " ";
+   tabLabel[i++] = (this.getMessage('uploadToOwncloudDlgLabel3').indexOf('???') == 0) ? 'links.</span>' : this.getMessage('uploadToOwncloudDlgLabel3');
+   var label = tabLabel.join("");
    
    //Create html for the upload bars
    var listProgressBar = {};
@@ -686,9 +699,10 @@ ownCloudZimlet.prototype.popUploadToOwncloudDlg = function(files) {
       label = label + "<td style='padding: 5px;'><div style='margin: 0px;' id='abort_"+progressId+"'></div></td></tr>";
    }
    label = label + "</table>";
-   
+
+   var dialogLabel = (this.getMessage('uploadToOwncloudDlgTitle').indexOf('???') == 0) ? 'Upload to ' + this._zimletContext.getConfig("owncloud_zimlet_app_title") : this.getMessage('uploadToOwncloudDlgTitle') + " " + this._zimletContext.getConfig("owncloud_zimlet_app_title");
    var dialog = this.makeDlg(
-      this.getMessage('uploadToOwncloudDlgTitle'),
+      dialogLabel,
       null,
       label,
       [DwtDialog.CANCEL_BUTTON]
@@ -726,6 +740,7 @@ ownCloudZimlet.prototype.abortUpload = function (progressId) {
       if(ownCloudZimletUploadList[i][0] == progressId) {
          var request = ownCloudZimletUploadList[i][3];
          ownCloudZimletUploadList.splice(i, 1);
+         ownCloudUploadFileCount = ownCloudUploadFileCount - 1;
          request.abort();
       }
    }
@@ -749,8 +764,8 @@ ownCloudZimlet.prototype.uploadFilesFromForm = function (files) {
 ownCloudZimlet.prototype._uploadFilesFromFormCbk = function (files , response) {
 
    var editor = appCtxt.getCurrentView().getHtmlEditor();
-   var uploadFileCount = 0;
-   this.status(this.getMessage("savingToOwncloud"), ZmStatusView.LEVEL_INFO);
+   var statusLabel = (this.getMessage('savingToOwncloud').indexOf('???') == 0) ? 'Saving to ' + this._zimletContext.getConfig("owncloud_zimlet_app_title") : this.getMessage('savingToOwncloud') + " " + this._zimletContext.getConfig("owncloud_zimlet_app_title");
+   this.status(statusLabel, ZmStatusView.LEVEL_INFO);
    //Load the upload progress dialog box
    var dlgResult = ownCloudZimletInstance.popUploadToOwncloudDlg(files);
    var listProgressBar = dlgResult[0];
@@ -789,11 +804,11 @@ ownCloudZimlet.prototype._uploadFilesFromFormCbk = function (files , response) {
       {
          //Manage upload aborted
          if(status!="0") {
-            uploadFileCount++;
+            ownCloudUploadFileCount++;
          }
 
          //Execute only when all files are uploaded
-         if(uploadFileCount == ownCloudZimletUploadList.length) {
+         if(ownCloudUploadFileCount == ownCloudZimletUploadList.length) {
             dialog.popdown();
             dialog.dispose();
             //Create shares and insert share links
@@ -803,6 +818,7 @@ ownCloudZimlet.prototype._uploadFilesFromFormCbk = function (files , response) {
 
             //reset upload list
             ownCloudZimletUploadList = new Array();
+            ownCloudUploadFileCount = 0;
          }
       };
       
@@ -894,9 +910,11 @@ ownCloudZimlet.prototype.addMenuButton = function (controller , menu) {
    if(!menu.getMenuItem (ID)) {
       var moveOp = menu.getMenuItem (ZmId.OP_MOVE);
       var moveOpIndex = menu.getItemIndex(moveOp);
+      var textLabel = (this.getMessage('menuLabel').indexOf('???') == 0) ? 'Save to ' + this._zimletContext.getConfig("owncloud_zimlet_app_title") : this.getMessage('menuLabel') + " " + this._zimletContext.getConfig("owncloud_zimlet_app_title");
+      var tooltipLabel = (this.getMessage('menuTooltip').indexOf('???') == 0) ? 'Save to ' + this._zimletContext.getConfig("owncloud_zimlet_app_title") : this.getMessage('menuTooltip') + " " + this._zimletContext.getConfig("owncloud_zimlet_app_title");
       var params = {
-         text : this.getMessage("menuLabel") ,
-         tooltip : this.getMessage("menuTooltip") ,
+         text : textLabel ,
+         tooltip : tooltipLabel ,
          image : "ownCloud-panelIcon" ,
          index : moveOpIndex + 1
       };

--- a/zimlet/tk_barrydegraaff_owncloud_zimlet.js
+++ b/zimlet/tk_barrydegraaff_owncloud_zimlet.js
@@ -945,7 +945,7 @@ ownCloudZimlet.prototype._menuButtonListener = function (controller) {
  * @param {ZmItem[]} zmObjects Objects dropped on the Zimlet Menu Item.
  */
 ownCloudZimlet.prototype.doDrop =
-  function(zmObjects) {
+  function(dropObjects) {
    /* Single selects result in an object passed,
    Multi selects results in an array of objects passed.
    Always make it an array */    

--- a/zimlet/tk_barrydegraaff_owncloud_zimlet.properties
+++ b/zimlet/tk_barrydegraaff_owncloud_zimlet.properties
@@ -1,0 +1,18 @@
+passwordPrompt = Your password is required for sharing links
+
+menuLabel = Save to ownCloud
+menuTooltip = Save to ownCloud
+passwordRequired = Your password is required to go further.
+
+useOwncloudDlgTitle = Large files must be shared with ownCloud
+useOwncloudDlgLabel1 = <span>Attachments larger than
+useOwncloudDlgLabel2 = MB will be <br>uploaded to ownCloud. A download link<br>will be included in your email.</span>
+
+uploadToOwncloudDlgTitle = Files uploading
+uploadToOwncloudDlgLabel1 = <span>The size of the files is over
+uploadToOwncloudDlgLabel2 = MB. The files will be uploaded as ownCloud links.</span>
+
+uploadToOwncloud = Upload to ownCloud
+savingToOwncloud = Saving to ownCloud
+
+sharePasswordLabel = password setup

--- a/zimlet/tk_barrydegraaff_owncloud_zimlet.properties
+++ b/zimlet/tk_barrydegraaff_owncloud_zimlet.properties
@@ -1,18 +1,18 @@
 passwordPrompt = Your password is required for sharing links
 
-menuLabel = Save to ownCloud
-menuTooltip = Save to ownCloud
+menuLabel = Save to
+menuTooltip = Save to
 passwordRequired = Your password is required to go further.
 
-useOwncloudDlgTitle = Large files must be shared with ownCloud
+useOwncloudDlgTitle = Large files must be shared with
 useOwncloudDlgLabel1 = <span>Attachments larger than
-useOwncloudDlgLabel2 = MB will be <br>uploaded to ownCloud. A download link<br>will be included in your email.</span>
+useOwncloudDlgLabel2 = MB will be <br>uploaded to
+useOwncloudDlgLabel3 = . A download link<br>will be included in your email.</span>
 
 uploadToOwncloudDlgTitle = Files uploading
 uploadToOwncloudDlgLabel1 = <span>The size of the files is over
-uploadToOwncloudDlgLabel2 = MB. The files will be uploaded as ownCloud links.</span>
+uploadToOwncloudDlgLabel2 = MB. The files will be uploaded as
+uploadToOwncloudDlgLabel3 = links.</span>
 
-uploadToOwncloud = Upload to ownCloud
-savingToOwncloud = Saving to ownCloud
-
-sharePasswordLabel = password setup
+uploadToOwncloud = Upload to
+savingToOwncloud = Saving to

--- a/zimlet/tk_barrydegraaff_owncloud_zimlet_fr.properties
+++ b/zimlet/tk_barrydegraaff_owncloud_zimlet_fr.properties
@@ -1,18 +1,18 @@
 passwordPrompt = Votre mot de passe est requis pour les liens de partage
 
-menuLabel = Sauvegarder dans ownCloud
-menuTooltip = Sauvegarder dans ownCloud
+menuLabel = Sauvegarder dans
+menuTooltip = Sauvegarder dans
 passwordRequired = Votre mot de passe est requis pour continuer.
 
-useOwncloudDlgTitle = Le partage des fichiers volumineux <br>doit s'effectuer via ownCloud
+useOwncloudDlgTitle = Le partage des fichiers volumineux <br>doit s'effectuer via
 useOwncloudDlgLabel1 = <span>Si la taille d'une pi\u00E8ce jointe d\u00E9passe
-useOwncloudDlgLabel2 = Mo, <br>celle-ci sera automatiquement import\u00E9e dans <br>ownCloud et le lien permettant de la <br>t\u00E9l\u00E9charger sera inclus dans votre e-mail.</span>
+useOwncloudDlgLabel2 = Mo, <br>celle-ci sera automatiquement import\u00E9e dans <br>
+useOwncloudDlgLabel3 = et le lien permettant de la <br>t\u00E9l\u00E9charger sera inclus dans votre e-mail.</span>
 
 uploadToOwncloudDlgTitle = Ajout des fichiers
 uploadToOwncloudDlgLabel1 = <span>La taille de votre fichier d\u00E9passe
-uploadToOwncloudDlgLabel2 = Mo. Ce fichier sera envoy\u00E9 sous forme de lien ownCloud</span>
+uploadToOwncloudDlgLabel2 = Mo. Ce fichier sera envoy\u00E9 sous forme de lien
+uploadToOwncloudDlgLabel3 = </span>
 
-uploadToOwncloud = Upload dans ownCloud
-savingToOwncloud = Sauvegarde dans ownCloud
-
-sharePasswordLabel = mot de passe du lien
+uploadToOwncloud = Upload dans
+savingToOwncloud = Sauvegarde dans

--- a/zimlet/tk_barrydegraaff_owncloud_zimlet_fr.properties
+++ b/zimlet/tk_barrydegraaff_owncloud_zimlet_fr.properties
@@ -1,0 +1,18 @@
+passwordPrompt = Votre mot de passe est requis pour les liens de partage
+
+menuLabel = Sauvegarder dans ownCloud
+menuTooltip = Sauvegarder dans ownCloud
+passwordRequired = Votre mot de passe est requis pour continuer.
+
+useOwncloudDlgTitle = Le partage des fichiers volumineux <br>doit s'effectuer via ownCloud
+useOwncloudDlgLabel1 = <span>Si la taille d'une pi\u00E8ce jointe d\u00E9passe
+useOwncloudDlgLabel2 = Mo, <br>celle-ci sera automatiquement import\u00E9e dans <br>ownCloud et le lien permettant de la <br>t\u00E9l\u00E9charger sera inclus dans votre e-mail.</span>
+
+uploadToOwncloudDlgTitle = Ajout des fichiers
+uploadToOwncloudDlgLabel1 = <span>La taille de votre fichier d\u00E9passe
+uploadToOwncloudDlgLabel2 = Mo. Ce fichier sera envoy\u00E9 sous forme de lien ownCloud</span>
+
+uploadToOwncloud = Upload dans ownCloud
+savingToOwncloud = Sauvegarde dans ownCloud
+
+sharePasswordLabel = mot de passe du lien


### PR DESCRIPTION
-removes the empty button in webdav app
-Add "save in webdav" option in the right click menu on mail, contacts,
appointments, task and files from the briefcase (under the move option in the menu).
-Add translations files to the zimlet (need the zimlet to be properly
deployed to work)
-Add a function to detect that a file uploaded as attachment to the mail
from the computer is too big (depending on zimbra server config of message max size), and upload it to webdav instead, then add a
sharing link in the mail body.